### PR TITLE
Render `latexdiff` on pull requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,21 @@ The **showyourwork-action** accepts any of the following inputs, all of which ar
 
 **Optional** Force-push output to branch :code:`<current-branch>-<output-branch-suffix>`? For example, if you've pushed a commit to the ``main`` branch, this action will by default compile your paper and force-push the output (the paper PDF as well as the ArXiV tarball, if enabled) to the branch ``main-pdf``. The *force* in *force-push* means this is not a typical ``git`` commit, as it will overwrite everything on that branch. This way, your repository won't get bloated over time with tons of committed output history. Default: :code:`pdf`.
 
+:code:`build-diff-on-pull-request`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Optional** Build the :code:`latexdiff` version of the article, in addition to the regular article? This will build a second PDF of the article, with all changes highlighted with respect to the base branch.
+
+:code:`latexdiff-url`
+~~~~~~~~~~~~~~~~~~~~
+
+**Optional** Specify the URL of the :code:`latexdiff` script to download. You may use this to set a custom version of :code:`latexdiff`.
+
+:code:`latexpand-url`
+~~~~~~~~~~~~~~~~~~~~
+
+**Optional** Specify the URL of the :code:`latexpand` script to download. You may use this to set a custom version of :code:`latexpand`.
+
 Environment variables
 ---------------------
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,14 @@ inputs:
     description: "Build a tarball for easy ArXiV submission?"
     required: false
     default: true
+  build-diff-on-pull-request:
+    description: "Build the `latexdiff` version of a PDF on pull requests"
+    required: false
+    default: true
+  latexdiff-url:
+    description: "URL to download `latexdiff`"
+    required: false
+    default: "https://raw.githubusercontent.com/ftilmann/latexdiff/1.3.2/latexdiff"
 branding:
   icon: "book-open"
   color: "red"

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: "URL to download `latexdiff`"
     required: false
     default: "https://raw.githubusercontent.com/ftilmann/latexdiff/1.3.2/latexdiff"
+  latexpand-url:
+    description: "URL to download `latexpand`"
+    required: false
+    default: "https://gitlab.com/latexpand/latexpand/-/raw/master/latexpand"
 branding:
   icon: "book-open"
   color: "red"

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,7 @@
 name: "showyourwork-action"
 author: "Rodrigo Luger"
 description: "Build reproducible scientific articles"
+runs-on: ubuntu-latest
 runs:
   using: "node12"
   main: "src/index.js"

--- a/process-pull-request/action.yml
+++ b/process-pull-request/action.yml
@@ -106,10 +106,12 @@ runs:
           let prNumber = ${{ steps.get-pr-number.outputs.result }};
           let outputBranch = `pull-request-${prNumber}-${branchSuffix}`;
           let pdfURL = `${htmlURL}/raw/${outputBranch}/${pdfName}`;
+          let diffURL = `${htmlURL}/raw/${outputBranch}/diff.pdf`;
           let branchURL = `${htmlURL}/tree/${outputBranch}`;
           let body = 
-            `Here is the compiled [article PDF](${pdfURL}) for the latest ` +
-            `commit. You can find additional build output at ` +
+            `Here is the compiled [article PDF](${pdfURL}), ` +
+            `as well as the [PDF with highlighted changes](${diffURL}), ` +
+            `of the latest commit. You can find additional build output at ` +
             `[${outputBranch}](${branchURL}).`;
 
           // Delete existing comment, if any

--- a/process-pull-request/action.yml
+++ b/process-pull-request/action.yml
@@ -111,7 +111,7 @@ runs:
           let body = 
             `Here is the compiled [article PDF](${pdfURL}), ` +
             `as well as the [PDF with highlighted changes](${diffURL}), ` +
-            `of the latest commit. You can find additional build output at ` +
+            `for the latest commit. You can find additional build output at ` +
             `[${outputBranch}](${branchURL}).`;
 
           // Delete existing comment, if any

--- a/src/publish.js
+++ b/src/publish.js
@@ -43,12 +43,12 @@ async function publishOutput() {
       shell.exec(`wget ${LATEXPAND_URL} && chmod +x latexpand`);
 
       // Checkout base version of ms.tex
-      shell.exec(`git show ${BASE_REF}:src/tex/ms.tex > src/tex/old.tex`);
-      // TODO: Flatten files to single latex file, to allow diff on
-      //       auxiliary files.
+      shell.exec(`./latexpand src/tex/${config["ms_name"]} -o .flat_new.tex`);
+      shell.exec(`git checkout ${BASE_REF} src/tex`);
+      shell.exec(`./latexpand src/tex/${config["ms_name"]} -o .flat_old.tex`);
 
       // Compute diff, and build
-      shell.exec(`perl latexdiff src/tex/old.tex src/tex/ms.tex > tmp.tex`);
+      shell.exec(`perl latexdiff src/tex/.flat_old.tex src/tex/.flat_new.tex > tmp.tex`);
       shell.exec(`mv tmp.tex src/tex/ms.tex`);
       shell.exec(`showyourwork build`);
       shell.exec(`cp ${config["ms_pdf"]} diff.pdf`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -42,6 +42,9 @@ async function publishOutput() {
         shell.exec(`wget ${LATEXDIFF_URL} && chmod +x latexdiff`);
         shell.exec(`wget ${LATEXPAND_URL} && chmod +x latexpand`);
 
+        // Install perl packages:
+        shell.exec(`perl -MCPAN -e "install Algorithm::Diff"`)
+
         // Checkout base version of ms.tex
         shell.exec(`./latexpand src/tex/${config["ms_name"]}.tex -o .flat_new.tex`);
         shell.exec(`git checkout ${BASE_REF} src/tex`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -16,7 +16,6 @@ async function publishOutput() {
   const GITHUB_WORKSPACE = shell.env["GITHUB_WORKSPACE"];
   const config = require(`${GITHUB_WORKSPACE}/.showyourwork/config.json`);
   const output = [config["ms_pdf"]];
-  core.startGroup("Uploading output");
 
   // Include the arxiv tarball?
   if (core.getInput("build-tarball") == "true") {
@@ -55,14 +54,14 @@ async function publishOutput() {
         shell.exec(`cp ${config["ms_pdf"]} diff.pdf`);
         shell.exec(`cp .bkup.pdf ${config["ms_pdf"]}`);
         output.push("diff.pdf");
-
-      core.endGroup();
+        core.endGroup();
+        
       } catch (error) {
-        // Print error message, but don't fail the action
-        console.log("Failed to generate diff with " + error.message);
+        // Raise warning, but don't fail the action
+        shell.echo(`::warning ::Failed to generate diff with ${error.message}`);
       }
     }
-
+    
     output.forEach(function (file) {
       shell.exec(`echo ${file} >> output.txt`);
     });
@@ -76,6 +75,7 @@ async function publishOutput() {
   }
 
   // Upload an artifact
+  core.startGroup("Uploading output");
   const artifactClient = artifact.create();
   await artifactClient.uploadArtifact("showyourwork-output", output, ".", {
     continueOnError: false,
@@ -108,6 +108,6 @@ async function publishOutput() {
         `${TARGET_BRANCH}`
     );
     shell.cd(GITHUB_WORKSPACE);
-    core.endGroup();
   }
+  core.endGroup();
 }

--- a/src/publish.js
+++ b/src/publish.js
@@ -33,7 +33,7 @@ async function publishOutput() {
       try {
         const LATEXDIFF_URL = core.getInput("latexdiff-url");
         const LATEXPAND_URL = core.getInput("latexpand-url"); 
-        const BASE_REF = github.context.payload.pull_request.base.ref;
+        const BASE_REF = github.context.payload.pull_request.base.sha;
 
         core.startGroup("Build article diff");
         shell.exec(`cp ${config["ms_pdf"]} .bkup.pdf`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -43,8 +43,7 @@ async function publishOutput() {
         shell.exec(`wget ${LATEXPAND_URL} && chmod +x latexpand`);
 
         // Install perl packages:
-        shell.exec(`wget -O - http://cpanmin.us | perl - --self-upgrade`);
-        shell.exec(`perl -MCPAN -e "install Algorithm::Diff"`);
+        shell.exec(`PERL_MM_USE_DEFAULT=1 perl -MCPAN -e "install Algorithm::Diff"`);
 
         // Checkout base version of ms.tex
         shell.exec(`./latexpand src/tex/${config["ms_name"]}.tex -o .flat_new.tex`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -44,13 +44,13 @@ async function publishOutput() {
         shell.exec(`wget ${LATEXPAND_URL} && chmod +x latexpand`);
 
         // Checkout base version of ms.tex
-        shell.exec(`./latexpand src/tex/${config["ms_name"]} -o .flat_new.tex`);
+        shell.exec(`./latexpand src/tex/${config["ms_name"]}.tex -o .flat_new.tex`);
         shell.exec(`git checkout ${BASE_REF} src/tex`);
-        shell.exec(`./latexpand src/tex/${config["ms_name"]} -o .flat_old.tex`);
+        shell.exec(`./latexpand src/tex/${config["ms_name"]}.tex -o .flat_old.tex`);
 
         // Compute diff, and build
         shell.exec(`./latexdiff src/tex/.flat_old.tex src/tex/.flat_new.tex > tmp.tex`);
-        shell.exec(`mv tmp.tex src/tex/ms.tex`);
+        shell.exec(`mv tmp.tex src/tex/${config["ms_name"]}.tex`);
         shell.exec(`showyourwork build`);
         shell.exec(`cp ${config["ms_pdf"]} diff.pdf`);
         shell.exec(`cp .bkup.pdf ${config["ms_pdf"]}`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -49,7 +49,7 @@ async function publishOutput() {
         shell.exec(`./latexpand src/tex/${config["ms_name"]} -o .flat_old.tex`);
 
         // Compute diff, and build
-        shell.exec(`perl latexdiff src/tex/.flat_old.tex src/tex/.flat_new.tex > tmp.tex`);
+        shell.exec(`./latexdiff src/tex/.flat_old.tex src/tex/.flat_new.tex > tmp.tex`);
         shell.exec(`mv tmp.tex src/tex/ms.tex`);
         shell.exec(`showyourwork build`);
         shell.exec(`cp ${config["ms_pdf"]} diff.pdf`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -43,7 +43,7 @@ async function publishOutput() {
         shell.exec(`wget ${LATEXPAND_URL} && chmod +x latexpand`);
 
         // Install perl packages:
-        shell.exec(`apt-get update -y && apt-get install -y libalgorithm-diff-perl`)
+        shell.exec(`sudo apt-get update -y && sudo apt-get install -y libalgorithm-diff-perl`)
 
         // Checkout base version of ms.tex
         shell.exec(`./latexpand src/tex/${config["ms_name"]}.tex -o .flat_new.tex`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -43,7 +43,7 @@ async function publishOutput() {
         shell.exec(`wget ${LATEXPAND_URL} && chmod +x latexpand`);
 
         // Install perl packages:
-        shell.exec(`PERL_MM_USE_DEFAULT=1 perl -MCPAN -e "install Algorithm::Diff"`);
+        shell.exec(`apt-get update -y && apt-get install -y libalgorithm-diff-perl`)
 
         // Checkout base version of ms.tex
         shell.exec(`./latexpand src/tex/${config["ms_name"]}.tex -o .flat_new.tex`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -42,8 +42,8 @@ async function publishOutput() {
         shell.exec(`wget ${LATEXDIFF_URL} && chmod +x latexdiff`);
         shell.exec(`wget ${LATEXPAND_URL} && chmod +x latexpand`);
 
-        // Install perl packages:
-        shell.exec(`sudo apt-get update -y && sudo apt-get install -y libalgorithm-diff-perl`)
+        // Install perl and texlive packages:
+        shell.exec(`sudo apt-get update -y && sudo apt-get install -y libalgorithm-diff-perl texlive-full`)
 
         // Checkout base version of ms.tex
         shell.exec(`./latexpand src/tex/${config["ms_name"]}.tex -o .flat_new.tex`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -43,7 +43,8 @@ async function publishOutput() {
         shell.exec(`wget ${LATEXPAND_URL} && chmod +x latexpand`);
 
         // Install perl packages:
-        shell.exec(`perl -MCPAN -e "install Algorithm::Diff"`)
+        shell.exec(`wget -O - http://cpanmin.us | perl - --self-upgrade`);
+        shell.exec(`perl -MCPAN -e "install Algorithm::Diff"`);
 
         // Checkout base version of ms.tex
         shell.exec(`./latexpand src/tex/${config["ms_name"]}.tex -o .flat_new.tex`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -54,6 +54,7 @@ async function publishOutput() {
         shell.exec(`showyourwork build`);
         shell.exec(`cp ${config["ms_pdf"]} diff.pdf`);
         shell.exec(`cp .bkup.pdf ${config["ms_pdf"]}`);
+        output.push("diff.pdf");
 
       core.endGroup();
       } catch (error) {

--- a/src/publish.js
+++ b/src/publish.js
@@ -51,7 +51,7 @@ async function publishOutput() {
         shell.exec(`./latexpand src/tex/${config["ms_name"]}.tex -o .flat_old.tex`);
 
         // Compute diff, and build
-        shell.exec(`./latexdiff src/tex/.flat_old.tex src/tex/.flat_new.tex > tmp.tex`);
+        shell.exec(`./latexdiff .flat_old.tex .flat_new.tex > tmp.tex`);
         shell.exec(`mv tmp.tex src/tex/${config["ms_name"]}.tex`);
         shell.exec(`showyourwork build`);
         shell.exec(`cp ${config["ms_pdf"]} diff.pdf`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -43,7 +43,7 @@ async function publishOutput() {
         shell.exec(`wget ${LATEXPAND_URL} && chmod +x latexpand`);
 
         // Install perl and texlive packages:
-        shell.exec(`sudo apt-get update -y && sudo apt-get install -y libalgorithm-diff-perl texlive-full`)
+        shell.exec(`sudo apt-get update -y && sudo apt-get install -y libalgorithm-diff-perl texlive-base`)
 
         // Checkout base version of ms.tex
         shell.exec(`./latexpand src/tex/${config["ms_name"]}.tex -o .flat_new.tex`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -36,6 +36,7 @@ async function publishOutput() {
       const BASE_REF = github.context.payload.pull_request.base.ref;
 
       core.startGroup("Build article diff");
+      shell.exec(`cp ${config["ms_pdf"]} .bkup.pdf`);
 
       // Download latexdiff and latexpand
       shell.exec(`wget ${LATEXDIFF_URL} && chmod +x latexdiff`);
@@ -50,6 +51,8 @@ async function publishOutput() {
       shell.exec(`perl latexdiff src/tex/old.tex src/tex/ms.tex > tmp.tex`);
       shell.exec(`mv tmp.tex src/tex/ms.tex`);
       shell.exec(`showyourwork build`);
+      shell.exec(`cp ${config["ms_pdf"]} diff.pdf`);
+      shell.exec(`cp .bkup ${config["ms_pdf"]}`);
 
       core.endGroup();
     }

--- a/src/publish.js
+++ b/src/publish.js
@@ -32,12 +32,14 @@ async function publishOutput() {
     // Build PDF diff
     if (core.getInput("build-diff-on-pull-request") == "true") {
       const LATEXDIFF_URL = core.getInput("latexdiff-url");
+      const LATEXPAND_URL = core.getInput("latexpand-url"); 
       const BASE_REF = github.context.payload.pull_request.base.ref;
 
       core.startGroup("Build article diff");
 
-      // Download latexdiff
-      shell.exec(`wget ${LATEXDIFF_URL}`)
+      // Download latexdiff and latexpand
+      shell.exec(`wget ${LATEXDIFF_URL} && chmod +x latexdiff`);
+      shell.exec(`wget ${LATEXPAND_URL} && chmod +x latexpand`);
 
       // Checkout base version of ms.tex
       shell.exec(`git show ${BASE_REF}:src/tex/ms.tex > src/tex/old.tex`);


### PR DESCRIPTION
This adds `latexdiff` functionality to `publish.js`. It introduces two new parameters: `build-diff-on-pull-request` and `latexdiff-url` that configure whether or not to build the diff, and what `latexdiff` URL to download, respectively. This addresses https://github.com/showyourwork/showyourwork/issues/123.

Right now there are a couple potential issues: the diff will only be generated with respect to the contents of `ms.tex`. If there are additional files, those will not be diffed. This could be fixed by using `latexpand` to flatten the files before diffing. However, I think this will work as a start.

I'm not sure how to actually test this @rodluger - could you have a look?