### PR TITLE
Adding argument to specify version of syw to install

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: "URL to download `latexpand`"
     required: false
     default: "https://gitlab.com/latexpand/latexpand/-/raw/master/latexpand"
+  pip-install-syw:
+    description: "A custom command to use when installing `showyourwork`: `pip install <pip-install-syw>`"
+    required: false
+    default: "showyourwork"
 branding:
   icon: "book-open"
   color: "red"

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: "A custom command to use when installing `showyourwork`: `pip install <pip-install-syw>`"
     required: false
     default: "showyourwork"
+  showyourwork-version:
+    description: "Version of `showyourwork` to use"
+    required: false
+    default: "latest"
 branding:
   icon: "book-open"
   color: "red"

--- a/action.yml
+++ b/action.yml
@@ -42,14 +42,16 @@ inputs:
     description: "URL to download `latexpand`"
     required: false
     default: "https://gitlab.com/latexpand/latexpand/-/raw/master/latexpand"
-  pip-install-syw:
-    description: "A custom command to use when installing `showyourwork`: `pip install <pip-install-syw>`"
-    required: false
-    default: "showyourwork"
   showyourwork-version:
     description: "Version of `showyourwork` to use"
     required: false
     default: "latest"
+  showyourwork-fork:
+    description: "The URL of a fork of the `showyourwork` repo"
+    required: false
+  showyourwork-ref:
+    description: "The name of a specific branch, tag, or commit on the fork of the `showyourwork` repo specified by `showyourwork-fork`"
+    required: false
 branding:
   icon: "book-open"
   color: "red"

--- a/src/conda.js
+++ b/src/conda.js
@@ -51,8 +51,14 @@ async function setupConda() {
   }
 
   // Always install the latest version of showyourwork
+  core.startGroup("Install showyourwork");
   const version = core.getInput("showyourwork-version");
-  shell.echo(`syw version: ${version}`);
+  const fork = core.getInput("showyourwork-fork");
+  const ref = core.getInput("showyourwork-ref");
+  shell.echo(`${version} ${fork} ${ref}`);
+  // if (fork || ref) {
+
+  // }
   const syw = core.getInput("pip-install-syw");
   exec(`pip install -U ${syw}`, "Install showyourwork");
 

--- a/src/conda.js
+++ b/src/conda.js
@@ -51,6 +51,8 @@ async function setupConda() {
   }
 
   // Always install the latest version of showyourwork
+  const version = core.getInput("showyourwork-version");
+  shell.echo(`syw version: ${version}`);
   const syw = core.getInput("pip-install-syw");
   exec(`pip install -U ${syw}`, "Install showyourwork");
 

--- a/src/conda.js
+++ b/src/conda.js
@@ -51,16 +51,23 @@ async function setupConda() {
   }
 
   // Always install the latest version of showyourwork
-  core.startGroup("Install showyourwork");
   const version = core.getInput("showyourwork-version");
   const fork = core.getInput("showyourwork-fork");
   const ref = core.getInput("showyourwork-ref");
-  shell.echo(`${version} ${fork} ${ref}`);
-  // if (fork || ref) {
-
-  // }
-  const syw = core.getInput("pip-install-syw");
-  exec(`pip install -U ${syw}`, "Install showyourwork");
+  let command = `pip install -U showyourwork`;
+  if (fork != "" || ref != "") {
+    if (fork == "") {
+      fork = "https://github.com/showyourwork/showyourwork.git";
+    }
+    if (ref == "") {
+      command = `pip install git+${fork}#egg=showyourwork`;
+    } else {
+      command = `pip install git+${fork}@${ref}#egg=showyourwork`;
+    }
+  } else if (version != "latest") {
+    command = `pip install showyourwork==${version}`;
+  }
+  exec(command, "Install showyourwork");
 
   // Display some info
   exec("conda info", "Conda info");

--- a/src/conda.js
+++ b/src/conda.js
@@ -51,7 +51,8 @@ async function setupConda() {
   }
 
   // Always install the latest version of showyourwork
-  exec("pip install -U showyourwork", "Install showyourwork");
+  const syw = core.getInput("pip-install-syw");
+  exec(`pip install -U ${syw}`, "Install showyourwork");
 
   // Display some info
   exec("conda info", "Conda info");

--- a/src/conda.js
+++ b/src/conda.js
@@ -60,12 +60,12 @@ async function setupConda() {
       fork = "https://github.com/showyourwork/showyourwork.git";
     }
     if (ref == "") {
-      command = `pip install git+${fork}#egg=showyourwork`;
+      command = `pip install -U git+${fork}#egg=showyourwork`;
     } else {
-      command = `pip install git+${fork}@${ref}#egg=showyourwork`;
+      command = `pip install -U git+${fork}@${ref}#egg=showyourwork`;
     }
   } else if (version != "latest") {
-    command = `pip install showyourwork==${version}`;
+    command = `pip install -U showyourwork==${version}`;
   }
   exec(command, "Install showyourwork");
 


### PR DESCRIPTION
The syntax is a little ugly and open to discussion, but this allows syntax like:

```yaml
      - name: Build the article PDF
        id: build
        uses: showyourwork/showyourwork-action@v1
        with:
          pip-install-syw: git+https://github.com/dfm/showyourwork.git#egg=showyourwork
```

to install syw from a fork. I expect this would be a pretty advanced use case so I'm not too sad if the syntax isn't great, but it could be better!

See updated syntax below.