### PR TITLE
Set channel priority to strict in build

### DIFF
--- a/src/conda.js
+++ b/src/conda.js
@@ -46,6 +46,7 @@ async function setupConda() {
     );
     exec("bash ./conda.sh -b -p ~/.conda && rm -f ./conda.sh", "Install conda");
     core.startGroup("Configure conda");
+    exec("conda config --set channel_priority strict");
     exec("conda config --add pkgs_dirs ~/conda_pkgs_dir");
     exec("conda install -y pip");
     core.endGroup();


### PR DESCRIPTION
The SYW GitHub actions are failing for me with the error:
```
Error: exec: Your conda installation is not configured to use strict channel priorities. This is however crucial for having robust and correct environments (for details, see https://conda-forge.org/docs/user/tipsandtricks.html). Please consider to configure strict priorities by executing 'conda config --set channel_priority strict'.
```
I think this might fix it? 

cc @dfm @rodluger 