### PR TITLE
Update to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: "Rodrigo Luger"
 description: "Build reproducible scientific articles"
 runs-on: ubuntu-latest
 runs:
-  using: "node12"
+  using: "node16"
   main: "src/index.js"
 inputs:
   conda-cache-number:


### PR DESCRIPTION
This will stop this warning appearing https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/