### PR TITLE
Emphasize `GITHUB_TOKEN` setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,21 @@ The **showyourwork-action** runs on `GitHub Actions <https://github.com/features
 
 This action is typically called in the workflow files ``.github/workflows/build.yml`` and ``.github/workflows/build-pull-request.yml`` of a `showyourwork <https://github.com/showyourwork/showyourwork>`_ article repository. For more information on GitHub Actions workflow files, see `here <https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions>`_.
 
+When setting up your GitHub repository, ensure that the GitHub Actions permissions for the ``GITHUB_TOKEN``
+secret are set to ``permissive``. First, go to
+
+.. raw:: html
+
+    <pre>
+    https://github.com/<span class="text-highlight">$USER/$REPO</span>/settings/actions
+    </pre>
+
+and change the permissions to ``permissive``:
+
+.. image:: https://show-your.work/en/latest/_images/workflow_permissions.png
+   :width: 60%
+   :align: center
+
 Inputs
 ------
 


### PR DESCRIPTION
I think this `GITHUB_TOKEN` setting has tripped me up maybe ~3 times now. I always end up reading the `actions` page, rather than the FAQ... Thus I think this tip about permissive settings for the `GITHUB_TOKEN` should be highlighted front-and-center on the `actions` page as that is where people will go when they're first setting it up.

@dfm could you review this?

---

Also - the "Suggest Edit" button on the rendered version seems to link to `actions.rst` on the main repository. How can we fix that?