### PR TITLE
Fix python version to what showyourwork needs

### DIFF
--- a/src/conda.js
+++ b/src/conda.js
@@ -47,7 +47,7 @@ async function setupConda() {
     exec("bash ./conda.sh -b -p ~/.conda && rm -f ./conda.sh", "Install conda");
     core.startGroup("Configure conda");
     exec("conda config --add pkgs_dirs ~/conda_pkgs_dir");
-    exec("conda install -y pip");
+    exec("conda install -y python'>=3.8,<3.11' pip");
     core.endGroup();
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,7 +53,7 @@ function exec_wrapper(cmd, group) {
  */
 function exec(cmd, group) {
   if (shell.test("-f", "~/.conda/etc/profile.d/conda.sh")) {
-    return exec_wrapper(`. ~/.conda/etc/profile.d/conda.sh && ${cmd}`, group);
+    return exec_wrapper(`. ~/.conda/etc/profile.d/conda.sh && conda activate base && ${cmd}`, group);
   } else {
     return exec_wrapper(cmd, group);
   }


### PR DESCRIPTION
Closes #13.

These are the applied changes:

 - `conda` `base` environment will now install the exact same `python` version required by `showyourwork`
 - the `exec` command now explicitly activates the `base` environment before running any command and not only executing the installed `conda.sh` script (which as far as I knew should have been sufficient to access to the `base` environment, but for some reason now it was not - maybe something changes in recent versions of `conda` or on the GitHub hosted runners; anyway, now we are sure that whatever is called will be using the `base` env `python` and `pip`)

@mkenworthy you can test this branch by calling my forked branch version of the github action from your project's GitHub workflow files like I did in my test project to fix this issue

https://github.com/HealthyPear/fix_showyourwork_action_issue_13/tree/main/.github/workflows

Please, let me know if this fixes showyourwork/showyourwork#505.
