### PR TITLE
Update render DAG config key for output

### DIFF
--- a/src/publish.js
+++ b/src/publish.js
@@ -23,7 +23,7 @@ async function publishOutput() {
   }
 
   // Include the DAG?
-  if (config["render_dag"]) {
+  if (config["dag"]["render"]) {
     output.push("dag.pdf");
   }
 


### PR DESCRIPTION
The DAG output was not saved because the action was looking at the config option as `config["render_dag"]`, but it should be config["dag"]["render"]; probably a missing update from an old update of showyourwork.

This was missed because _showyourwork_ currently does not have a remote DAG test rendering, but at least a local one...