### PR TITLE
Support for self-hosted runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run test suite
+        run: node --test

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,127 @@ The **showyourwork-action** runs on `GitHub Actions <https://github.com/features
 
 This action is typically called in the workflow files ``.github/workflows/build.yml`` and ``.github/workflows/build-pull-request.yml`` of a `showyourwork <https://github.com/showyourwork/showyourwork>`_ article repository. For more information on GitHub Actions workflow files, see `here <https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions>`_.
 
+Self-hosted runners
+-------------------
+
+.. important:: 
+
+   Using self-hosted runners in public repositories is not recommended.
+   Forks of your public repository can potentially run dangerous code on your self-hosted runner by creating a pull request.
+   Setup your repository settings accordingly to limit who can fork, create PRs and the use of your self-hosted runner to trusted users only.
+
+.. note::
+
+   This is a very first approach to running the **showyourwork-action** on a self-hosted runner. 
+   It is not yet fully tested, and there may be some rough edges.
+   Maybe there is even an easier way to do this that we haven't thought of yet...
+   If you run into issues, please open an issue on `showyourwork-action <https://github.com/showyourwork/showyourwork-action/issues>`_.
+
+The action can also run on a self-hosted runner.
+This is useful when the build needs:
+
+- access to a specific machine or private network,
+- more computing power or time limits than what is available on GitHub-hosted runners,
+- an existing conda installation that is not available on GitHub-hosted runners.
+
+This section describes how to setup your own self-hosted runner using Docker after you created your project with _showyourwork_.
+The choice of Docker is for keeping the runner isolated from the rest of the host system.
+
+.. note::
+
+   Other containerization solutions might also work, but we have not tested them yet.
+
+After you created a project with showyourwork, you can set up a self-hosted runner as follows:
+
+1. Install `Docker <https://www.docker.com/products/docker-desktop/>`_ on the machine that will host the runner.
+   Make sure the Docker daemon is running and that your user can access it.
+
+   .. code-block:: bash
+
+      docker --version
+      docker info
+
+2. Build a runner image from the included ``docker/runner.Dockerfile``.
+
+   .. code-block:: bash
+
+      git clone https://github.com/showyourwork/showyourwork-action.git
+      cd showyourwork-action
+      docker build -f docker/runner.Dockerfile -t local-github-runner .
+
+3. Start the creation of the new self-hosted runner from the GitHub UI of your repository under ``Settings -> Actions -> Runners``,
+   but do not proceed with the registration yet. Instead, copy the command that GitHub provides to register the runner, 
+   which will look something like this:
+
+   .. code-block:: bash
+
+      ./config.sh --url https://github.com/$YOUR_USERNAME/$REPO --token <RUNNER_TOKEN>
+
+4. Start a persistent runner container so it remains associated with the GitHub runner registration.
+
+   The recommended flow is to start the container in detached mode and register it once.
+   The first part of the configuration command is the one you get from the step above.
+   Use the token for this repository and then let the runner keep running in the background.
+
+   .. code-block:: bash
+
+      docker run -d --name github-runner \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v "$PWD":/home/runner/work \
+        -w /home/runner/work \
+        --entrypoint bash \
+        local-github-runner -c 'cd /home/runner && ./config.sh --url https://github.com/$YOUR_USERNAME/$REPO --token <RUNNER_TOKEN> --name local-docker-runner --labels self-hosted,linux,arm64 --unattended && ./run.sh'
+
+  .. note::
+
+     Replace ``arm64`` with the architecture of your runner if it differs (for example, ``x64`` on an x86_64 machine).
+
+   If you need to inspect the container interactively after it has already been configured, you can connect to it later with:
+
+   .. code-block:: bash
+
+      docker exec -it github-runner bash
+
+   or by using the Docker Desktop application.
+
+   
+
+   If you prefer to configure the runner interactively before starting it, do so in a temporary container, but keep the long-lived runner itself as a detached container that is not removed automatically.
+
+5. In the workflow file for the sample project, set ``runs-on: [self-hosted, linux, x64]`` (or the labels you configured when registering the runner). This is the key step that selects the self-hosted machine for the build.
+
+   .. code-block:: yaml
+
+      name: build
+
+      on:
+        push:
+        pull_request:
+
+      jobs:
+        build:
+          runs-on: [self-hosted, linux, x64]
+          steps:
+            - uses: actions/checkout@v4
+            - uses: showyourwork/showyourwork-action@main
+              env:
+                SANDBOX_TOKEN: ${{ secrets.SANDBOX_TOKEN }}
+                OVERLEAF_TOKEN: ${{ secrets.OVERLEAF_TOKEN }}
+
+6. If the runner host or container already contains conda at a non-standard location, provide that path with the ``conda-installation-path`` input so the action reuses it instead of trying to install a fresh copy in the default location.
+
+   .. code-block:: yaml
+
+      - uses: showyourwork/showyourwork-action@main
+        with:
+          conda-installation-path: /opt/conda
+
+7. Push the workflow and then trigger the build. The GitHub runner will start inside the Docker container, fetch the repository, and execute the action on the self-hosted machine.
+
+8. If the runner is hosted on a remote server rather than a local machine, SSH can be used to provision it and inspect the host, but the workflow still runs through the GitHub Actions runner itself. Docker remains useful on shared machines because it isolates each build from the rest of the host system.
+
+For a real project, this setup can be reused directly on a dedicated self-hosted machine or on an SSH-accessible host. The important point is that the runner is still the GitHub Actions agent; Docker and SSH are only mechanisms for isolating or reaching the execution environment.
+
 When setting up your GitHub repository, ensure that the GitHub Actions permissions for the ``GITHUB_TOKEN``
 secret are set to ``permissive``. First, go to
 
@@ -51,6 +172,11 @@ The **showyourwork-action** accepts any of the following inputs, all of which ar
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Optional** Bump this number to reset the :code:`conda` cache. The behavior is similar to that of ``article-cache-number`` above. Default: :code:`0`. Note that you can disable conda caching by setting this variable to `null` or to an empty value.
+
+:code:`conda-installation-path`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Optional** Path to an existing conda installation to reuse on the runner. This is useful for self-hosted runners that already provide conda at a non-standard location. Default: :code:`~/.conda`.
 
 :code:`github-token`
 ~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,13 @@ This is useful when the build needs:
 - more computing power or time limits than what is available on GitHub-hosted runners,
 - an existing conda installation that is not available on GitHub-hosted runners.
 
+Using Docker
+^^^^^^^^^^^^
+
+This is the recommended way if you have access to a Docker installation on the machine you
+want to use as it provides a true isolated environment for the runner, the conda installation
+and the build output.
+
 This section describes how to setup your own self-hosted runner using Docker after you created your project with _showyourwork_.
 The choice of Docker is for keeping the runner isolated from the rest of the host system.
 
@@ -133,6 +140,32 @@ After you created a project with showyourwork, you can set up a self-hosted runn
 8. If the runner is hosted on a remote server rather than a local machine, SSH can be used to provision it and inspect the host, but the workflow still runs through the GitHub Actions runner itself. Docker remains useful on shared machines because it isolates each build from the rest of the host system.
 
 For a real project, this setup can be reused directly on a dedicated self-hosted machine or on an SSH-accessible host. The important point is that the runner is still the GitHub Actions agent; Docker and SSH are only mechanisms for isolating or reaching the execution environment.
+
+Use runner natively
+^^^^^^^^^^^^^^^^^^^
+
+This is the approach you can use if e.g. you cannot use Docker ir similar solutions or you can
+but for some reason the image does not build or cannot be used properly.
+It is assumed that the machine can connect to GitHub.
+
+1. Go to your project repository under ``Settings -> Actions -> Runners`` and click on ``New self-hosted runner``.
+2. Follow the instructions to download and configure the runner on your machine (in a path you control if it is a shared machine).
+3. Create a new repository variable to store the path to your conda installation within the runner.
+   For example if you installed the runner under /home/me/github_runners/my_runner create a new variable
+   called ``CONDA_INSTALLATION_PATH`` with value ``/home/me/github_runners/my_runner/conda_installation``.
+4. Update your project build workflow files to use this additional variable as input to the action. For example:
+
+   .. code-block:: yaml
+
+      - uses: showyourwork/showyourwork-action@main
+        with:
+          conda-installation-path: ${{ vars.CONDA_INSTALLATION_PATH }}
+
+Please, remember that the labels under the `runs-on` key need to coincide with those you specify
+when registering the runner.
+
+Permissions
+-----------
 
 When setting up your GitHub repository, ensure that the GitHub Actions permissions for the ``GITHUB_TOKEN``
 secret are set to ``permissive``. First, go to

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Bump this number to reset the conda cache"
     required: false
     default: "0"
+  conda-installation-path:
+    description: "Path to an existing conda installation to reuse on the runner"
+    required: false
+    default: "~/.conda"
   article-cache-number:
     description: "Bump this number to reset the article cache"
     required: false

--- a/docker/runner.Dockerfile
+++ b/docker/runner.Dockerfile
@@ -1,0 +1,25 @@
+FROM ghcr.io/actions/actions-runner:latest
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        sudo \
+        tree \
+        wget \
+        docker.io \
+    && rm -rf /var/lib/apt/lists/* \
+    && usermod -aG docker runner \
+    && echo 'runner ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/runner \
+    && chmod 0440 /etc/sudoers.d/runner
+
+USER runner
+ENV HOME=/home/runner
+ENV RUNNER_ALLOW_RUNASROOT=1
+
+WORKDIR /home/runner

--- a/src/conda.js
+++ b/src/conda.js
@@ -3,7 +3,12 @@ const core = require("@actions/core");
 const cache = require("@actions/cache");
 const shell = require("shelljs");
 const constants = require("./constants.js");
-const { exec, getCondaActivationScriptPath, getCondaInstallationPath } = require("./utils");
+const {
+  exec,
+  getCondaActivationScriptPath,
+  getCondaInstallationPath,
+  getMinicondaInstallerUrl,
+} = require("./utils");
 
 // Exports
 module.exports = { setupConda };
@@ -41,8 +46,9 @@ async function setupConda() {
 
   // Download and setup conda
   if (!shell.test("-f", getCondaActivationScriptPath(CONDA_INSTALLATION_PATH))) {
+    const minicondaInstallerUrl = getMinicondaInstallerUrl(process.arch);
     exec(
-      "wget --no-verbose https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ./conda.sh",
+      `wget --no-verbose ${minicondaInstallerUrl} -O ./conda.sh`,
       "Download conda"
     );
     exec(`bash ./conda.sh -b -p ${CONDA_INSTALLATION_PATH} && rm -f ./conda.sh`, "Install conda");

--- a/src/conda.js
+++ b/src/conda.js
@@ -3,7 +3,7 @@ const core = require("@actions/core");
 const cache = require("@actions/cache");
 const shell = require("shelljs");
 const constants = require("./constants.js");
-const { exec } = require("./utils");
+const { exec, getCondaActivationScriptPath, getCondaInstallationPath } = require("./utils");
 
 // Exports
 module.exports = { setupConda };
@@ -14,7 +14,8 @@ const SHOWYOUWORK_SPEC = core.getInput("showyourwork-spec");
 const RUNNER_OS = shell.env["RUNNER_OS"];
 const conda_key = `conda-${constants.conda_cache_version}-${RUNNER_OS}-${CONDA_CACHE_NUMBER}`;
 const conda_restoreKeys = [];
-const conda_paths = ["~/.conda", "~/.condarc", "~/conda_pkgs_dir"];
+const CONDA_INSTALLATION_PATH = getCondaInstallationPath();
+const conda_paths = [CONDA_INSTALLATION_PATH, "~/.condarc", "~/conda_pkgs_dir"];
 
 // We'll cache the article unless the user set the cache number to `null` (or empty).
 const CACHE_CONDA = (
@@ -39,12 +40,12 @@ async function setupConda() {
   }
 
   // Download and setup conda
-  if (!shell.test("-d", "~/.conda")) {
+  if (!shell.test("-f", getCondaActivationScriptPath(CONDA_INSTALLATION_PATH))) {
     exec(
-      "wget --no-verbose https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ./conda.sh", 
+      "wget --no-verbose https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ./conda.sh",
       "Download conda"
     );
-    exec("bash ./conda.sh -b -p ~/.conda && rm -f ./conda.sh", "Install conda");
+    exec(`bash ./conda.sh -b -p ${CONDA_INSTALLATION_PATH} && rm -f ./conda.sh`, "Install conda");
     core.startGroup("Configure conda");
     exec("conda config --add pkgs_dirs ~/conda_pkgs_dir");
     exec("conda install -y python'>=3.11' pip");

--- a/src/conda.js
+++ b/src/conda.js
@@ -7,6 +7,7 @@ const {
   exec,
   getCondaActivationScriptPath,
   getCondaInstallationPath,
+  getCondaPythonVersionSpec,
   getMinicondaInstallerUrl,
 } = require("./utils");
 
@@ -54,7 +55,7 @@ async function setupConda() {
     exec(`bash ./conda.sh -b -p ${CONDA_INSTALLATION_PATH} && rm -f ./conda.sh`, "Install conda");
     core.startGroup("Configure conda");
     exec("conda config --add pkgs_dirs ~/conda_pkgs_dir");
-    exec("conda install -y python'>=3.11' pip");
+    exec(`conda install -y "${getCondaPythonVersionSpec()}" pip`);
     core.endGroup();
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,7 @@ module.exports = {
   getInputAsArray,
   getCondaInstallationPath,
   getCondaActivationScriptPath,
+  getMinicondaInstallerUrl,
 };
 
 /**
@@ -36,6 +37,21 @@ function getCondaInstallationPath(customPath) {
  */
 function getCondaActivationScriptPath(customPath) {
   return `${getCondaInstallationPath(customPath)}/etc/profile.d/conda.sh`;
+}
+
+/**
+ * Get the Miniconda installer URL matching the current runner architecture.
+ *
+ * GitHub-hosted and self-hosted runners may be x86_64 or arm64/aarch64,
+ * and using the wrong installer binary causes Rosetta errors on Apple Silicon.
+ *
+ * @param {string} [arch] - Optional architecture string. Defaults to the host architecture.
+ * @returns {string} The Miniconda installer URL.
+ */
+function getMinicondaInstallerUrl(arch) {
+  const normalizedArch = (arch ?? process.arch ?? "x64").toLowerCase();
+  const targetArch = normalizedArch.includes("arm") || normalizedArch.includes("aarch") ? "aarch64" : "x86_64";
+  return `https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${targetArch}.sh`;
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,7 @@ module.exports = {
   getInputAsArray,
   getCondaInstallationPath,
   getCondaActivationScriptPath,
+  getCondaPythonVersionSpec,
   getMinicondaInstallerUrl,
 };
 
@@ -37,6 +38,18 @@ function getCondaInstallationPath(customPath) {
  */
 function getCondaActivationScriptPath(customPath) {
   return `${getCondaInstallationPath(customPath)}/etc/profile.d/conda.sh`;
+}
+
+/**
+ * Get the supported Python version range for conda envs in this action.
+ *
+ * The showyourwork dependency stack currently fails on Python 3.14 because
+ * ``immutables`` does not ship working wheels for that version yet.
+ *
+ * @returns {string} A conda version specifier compatible with the currently supported stack.
+ */
+function getCondaPythonVersionSpec() {
+  return "python>=3.11,<3.14";
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,36 @@ module.exports = {
   makeId,
   exec,
   getInputAsArray,
+  getCondaInstallationPath,
+  getCondaActivationScriptPath,
 };
+
+/**
+ * Get the conda installation path used by the action.
+ *
+ * Users can override the default installation prefix by providing the
+ * ``conda-installation-path`` input.
+ *
+ * @param {string} [customPath] - Optional path override.
+ * @returns {string} The resolved conda installation path.
+ */
+function getCondaInstallationPath(customPath) {
+  const inputPath = customPath ?? core.getInput("conda-installation-path");
+  if (typeof inputPath === "string" && inputPath.trim() !== "") {
+    return inputPath.trim();
+  }
+  return "~/.conda";
+}
+
+/**
+ * Get the activation script for the selected conda installation.
+ *
+ * @param {string} [customPath] - Optional path override.
+ * @returns {string} The path to ``conda.sh``.
+ */
+function getCondaActivationScriptPath(customPath) {
+  return `${getCondaInstallationPath(customPath)}/etc/profile.d/conda.sh`;
+}
 
 /**
  * Generate a random hash.
@@ -52,8 +81,9 @@ function exec_wrapper(cmd, group) {
  *
  */
 function exec(cmd, group) {
-  if (shell.test("-f", "~/.conda/etc/profile.d/conda.sh")) {
-    return exec_wrapper(`. ~/.conda/etc/profile.d/conda.sh && conda activate base && ${cmd}`, group);
+  const condaActivationScriptPath = getCondaActivationScriptPath();
+  if (shell.test("-f", condaActivationScriptPath)) {
+    return exec_wrapper(`. ${condaActivationScriptPath} && conda activate base && ${cmd}`, group);
   } else {
     return exec_wrapper(cmd, group);
   }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,10 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { getCondaInstallationPath, getCondaActivationScriptPath } = require('../src/utils');
+const {
+  getCondaInstallationPath,
+  getCondaActivationScriptPath,
+  getMinicondaInstallerUrl,
+} = require('../src/utils');
 
 test('uses the default conda prefix when no override is provided', () => {
   assert.equal(getCondaInstallationPath(), '~/.conda');
@@ -10,4 +14,14 @@ test('uses the default conda prefix when no override is provided', () => {
 test('uses a custom conda installation path when provided', () => {
   assert.equal(getCondaInstallationPath('/opt/conda'), '/opt/conda');
   assert.equal(getCondaActivationScriptPath('/opt/conda'), '/opt/conda/etc/profile.d/conda.sh');
+});
+
+test('uses the arm64 Miniconda installer on arm64 runners', () => {
+  assert.match(getMinicondaInstallerUrl('arm64'), /aarch64/);
+  assert.match(getMinicondaInstallerUrl('aarch64'), /aarch64/);
+});
+
+test('uses the x86_64 Miniconda installer on x86_64 runners', () => {
+  assert.match(getMinicondaInstallerUrl('x86_64'), /x86_64/);
+  assert.match(getMinicondaInstallerUrl('amd64'), /x86_64/);
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const {
   getCondaInstallationPath,
   getCondaActivationScriptPath,
+  getCondaPythonVersionSpec,
   getMinicondaInstallerUrl,
 } = require('../src/utils');
 
@@ -16,6 +17,10 @@ test('uses a custom conda installation path when provided', () => {
   assert.equal(getCondaActivationScriptPath('/opt/conda'), '/opt/conda/etc/profile.d/conda.sh');
 });
 
+test('pins the conda environment to a supported Python range', () => {
+  assert.equal(getCondaPythonVersionSpec(), 'python>=3.11,<3.14');
+});
+
 test('uses the arm64 Miniconda installer on arm64 runners', () => {
   assert.match(getMinicondaInstallerUrl('arm64'), /aarch64/);
   assert.match(getMinicondaInstallerUrl('aarch64'), /aarch64/);
@@ -25,3 +30,4 @@ test('uses the x86_64 Miniconda installer on x86_64 runners', () => {
   assert.match(getMinicondaInstallerUrl('x86_64'), /x86_64/);
   assert.match(getMinicondaInstallerUrl('amd64'), /x86_64/);
 });
+

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,13 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { getCondaInstallationPath, getCondaActivationScriptPath } = require('../src/utils');
+
+test('uses the default conda prefix when no override is provided', () => {
+  assert.equal(getCondaInstallationPath(), '~/.conda');
+  assert.equal(getCondaActivationScriptPath(), '~/.conda/etc/profile.d/conda.sh');
+});
+
+test('uses a custom conda installation path when provided', () => {
+  assert.equal(getCondaInstallationPath('/opt/conda'), '/opt/conda');
+  assert.equal(getCondaActivationScriptPath('/opt/conda'), '/opt/conda/etc/profile.d/conda.sh');
+});


### PR DESCRIPTION
This is very much a work in progress!

The idea for the moment is to provide a Dockerfile based on GitHub's actions runner.
Inside this container register a new runner, connected to some repo (for my own testing I created this branch since the local project needs to know which version of our action to use - aka this branch)

I was not sure but I tried to add support for a non-standard conda path (read: non standard wrt the one we are currently hardcoding here...) because the reason why I chose to start with Docker is that I do not like the idea that the runner / action meddles with your personal/local conda installation.

Successfully tested on:

- [x] macos 15.7.7
- [x] linux server via SSH

Closes #11 
Closes #27
Closes #28